### PR TITLE
Replace special character with html equivalent

### DIFF
--- a/src/components/Stages/End/EndText.js
+++ b/src/components/Stages/End/EndText.js
@@ -18,7 +18,7 @@ const EndText = React.memo(props => (
       href="https://github.com/sfatihk/react-world"
     >
       <h1 style={{ color: "#6B6B6B" }}>
-        >View
+        &gt;View
         <br />
         Source
       </h1>


### PR DESCRIPTION
To fix the linter warnings of the ">" character mistaken by HTML tags.
- Replace ">" with "gt;"

